### PR TITLE
레이아웃 작업

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link'
+
+const Header = () => {
+  return (
+    <header>
+      <nav className="flex items-center justify-between flex-wrap bg-blue-500 p-6">
+        <div className="flex items-center flex-shrink-0 text-white mr-6">
+          <Link href="/" className="font-semibold text-xl tracking-tight">
+            Codebox
+          </Link>
+        </div>
+        <div className="w-full block flex-grow lg:flex lg:items-center lg:w-auto">
+          <div className="text-sm lg:flex-grow">
+            <Link
+              href="/problem"
+              className="block mt-4 lg:inline-block lg:mt-0 text-white hover:text-blue-200 mr-4"
+            >
+              문제
+            </Link>
+          </div>
+        </div>
+      </nav>
+    </header>
+  )
+}
+export default Header

--- a/components/layout/index.tsx
+++ b/components/layout/index.tsx
@@ -1,0 +1,14 @@
+import { useState } from 'react'
+import pusherClient from '@utils/pusherClient'
+import Link from 'next/link'
+import Header from './header'
+const Layout: React.FC<React.PropsWithChildren> = ({ children }) => {
+  return (
+    <>
+      <Header />
+      <main>{children}</main>
+    </>
+  )
+}
+
+export default Layout

--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -1,6 +1,11 @@
 import '../styles/globals.scss'
 import type { AppProps } from 'next/app'
+import Layout from '@components/layout'
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  )
 }


### PR DESCRIPTION
# 개요
- 임시 레이아웃 컴포넌트를 만들어 `_app.tsx` 사용하여 공통적으로 사용 할 수 있도록 작업 (예외가 필요하다면 해당 [링크](https://nextjs.org/docs/basic-features/layouts) 참조)
- 임시적으로 만든 문제 페이지는 다른 브렌치를 고려하여 작업하여 현재는 404 페이지임

# 리뷰어 참조
- 레이아웃은 모든 페이지에서 사용되지만 _app.tsx 에서만 사용 될 확률이 높아 공통적으로 컴포넌트를 묶는`shared` 폴더 밑에 현재는 나두지 않았음