### PR TITLE
유저 페이지 구현

### DIFF
--- a/pages/[username]/index.page.tsx
+++ b/pages/[username]/index.page.tsx
@@ -1,0 +1,28 @@
+import { useRouter } from 'next/router'
+import { useMember } from './useMember'
+import { useState } from 'react'
+import { Avatar } from 'antd'
+const Landing = () => {
+  const router = useRouter()
+  const [nickname, setNickname] = useState('')
+  const [profile, setProfile] = useState('')
+  const { username } = router.query
+  useMember({
+    variables: { username },
+    onCompleted({ matchedUser }) {
+      setNickname(matchedUser.nickname)
+      setProfile(matchedUser.profileImage)
+    },
+  })
+  return (
+    <>
+      <main className="container px-20 w-full pt-[7vh]">
+        <Avatar src={profile} size={128} />
+        <p className="text-black text-30">{nickname}</p>
+        <span className="text-neutral-400 text-20">{username}</span>
+      </main>
+    </>
+  )
+}
+
+export default Landing

--- a/pages/[username]/useMember.ts
+++ b/pages/[username]/useMember.ts
@@ -1,0 +1,26 @@
+import {
+  OperationVariables,
+  QueryHookOptions,
+  gql,
+  useQuery,
+} from '@apollo/client'
+
+const GET_PROBLEMS = gql`
+  query a($username: String){
+    matchedUser(username:$username){
+      nickname
+      username
+      profileImage
+    }
+  }
+`
+
+export const useMember = (
+  options?: QueryHookOptions<any, OperationVariables>
+) => {
+  const { data, ...rest } = useQuery<any>(GET_PROBLEMS, options)
+  return {
+    data: data,
+    ...rest,
+  }
+}


### PR DESCRIPTION
## 🔥 작업 목록
1. ` https://host/[username]` 로 유저 이름으로 접근할 수 있게 페이지 생성
2. 그래프 QL로 유저 정보 가져오기

## 🙏 리뷰어 참고 사항 
- 일단 자료형을 matchUser라는 wrapper 프로퍼티를 벗겨낼 수 있는 좋은 방법이 없어서 useMember를 임시적으로 any로 했는데 개선이 필요할 꺼 같습니다.
- useState를 redux로 변환 필요함!